### PR TITLE
Avoid "shadowing outer local variable - command"

### DIFF
--- a/lib/protocol/hpack/compressor.rb
+++ b/lib/protocol/hpack/compressor.rb
@@ -194,8 +194,8 @@ module Protocol
 				
 				commands = @context.encode(headers)
 				
-				commands.each do |command|
-					write_header(command)
+				commands.each do |c|
+					write_header(c)
 				end
 				
 				return @buffer


### PR DESCRIPTION
## Description

This PR attempts to avoid a Ruby warning.

    gems/protocol-hpack-1.4.2/lib/protocol/hpack/compressor.rb:197: warning: shadowing outer local variable - command


### Types of Changes

- Maintenance.

### Testing

...