### PR TITLE
fix running `rake huffman:generate_table`

### DIFF
--- a/tasks/huffman.rb
+++ b/tasks/huffman.rb
@@ -7,12 +7,12 @@
 # Copyright, 2016, by George Ulmer.
 # Copyright, 2018-2024, by Samuel Williams.
 
-require_relative '../lib/http/hpack/huffman'
+require_relative '../lib/protocol/hpack/huffman'
 
 require 'set'
 
 module Huffman
-	BITS_AT_ONCE = HTTP::HPACK::Huffman::BITS_AT_ONCE
+	BITS_AT_ONCE = Protocol::HPACK::Huffman::BITS_AT_ONCE
 	EOS = 256
 
 	class Node
@@ -49,7 +49,7 @@ module Huffman
 
 		def self.generate_tree
 			@root = new(0)
-			HTTP::HPACK::Huffman::CODES.each_with_index do |c, chr|
+			Protocol::HPACK::Huffman::CODES.each_with_index do |c, chr|
 				code, len = c
 				@root.add(code, len, chr)
 			end
@@ -71,7 +71,7 @@ module Huffman
 
 				(1 << BITS_AT_ONCE).times do |input|
 					n = node
-					emit = ''
+					emit = +''
 					(BITS_AT_ONCE - 1).downto(0) do |i|
 						bit = (input & (1 << i)).zero? ? 0 : 1
 						n = n.next[bit]
@@ -107,7 +107,7 @@ module Huffman
 				id += 1
 			end
 
-			File.open(File.expand_path('../lib/http/hpack/huffman/machine.rb', File.dirname(__FILE__)), 'w') do |f|
+			File.open(File.expand_path('../lib/protocol/hpack/huffman/machine.rb', File.dirname(__FILE__)), 'w') do |f|
 				f.print <<HEADER
 # frozen_string_literal: true
 


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

Running `rake huffman:generate_table` wound up with a number of errors, since it seems like this task has not been run in a while.  This PR restores the ability to regenerate the table.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [X] I tested my changes locally.  No changes to the `machine.rb` file were observed.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
