### PR TITLE
make `Huffman` methods class methods to avoid unnecessary allocations

### DIFF
--- a/lib/protocol/hpack/compressor.rb
+++ b/lib/protocol/hpack/compressor.rb
@@ -118,7 +118,7 @@ module Protocol
 			# @return [String] binary string
 			def write_string(string, huffman = self.huffman)
 				if huffman != :never
-					encoded = Huffman.new.encode(string)
+					encoded = Huffman.encode(string)
 					
 					if huffman == :shorter and encoded.bytesize >= string.bytesize
 						encoded = nil

--- a/lib/protocol/hpack/decompressor.rb
+++ b/lib/protocol/hpack/decompressor.rb
@@ -89,7 +89,7 @@ module Protocol
 				
 				raise CompressionError, "Invalid string length, got #{string.bytesize}, expecting #{length}!" unless string.bytesize == length
 				
-				string = Huffman.new.decode(string) if huffman
+				string = Huffman.decode(string) if huffman
 				
 				return string.force_encoding(Encoding::UTF_8)
 			end

--- a/lib/protocol/hpack/huffman.rb
+++ b/lib/protocol/hpack/huffman.rb
@@ -22,7 +22,7 @@ module Protocol
 			#
 			# @param str [String]
 			# @return [String] binary string
-			def encode(str)
+			def self.encode(str)
 				bitstring = str.each_byte.map {|chr| ENCODE_TABLE[chr]}.join
 				bitstring << '1' * ((8 - bitstring.size) % 8)
 				[bitstring].pack('B*')
@@ -33,7 +33,7 @@ module Protocol
 			# @param buf [Buffer]
 			# @return [String] binary string
 			# @raise [CompressionError] when Huffman coded string is malformed
-			def decode(buffer)
+			def self.decode(buffer)
 				emit = String.new.b
 				state = 0 # start state
 

--- a/test/protocol/hpack/huffman.rb
+++ b/test/protocol/hpack/huffman.rb
@@ -9,8 +9,6 @@
 require 'protocol/hpack/huffman'
 
 describe Protocol::HPACK::Huffman do
-	let(:huffman) {subject.new}
-	
 	huffman_examples = [ # plain, encoded
 		['www.example.com', 'f1e3c2e5f23a6ba0ab90f4ff'],
 		['no-cache',        'a8eb10649cbf'],
@@ -20,7 +18,7 @@ describe Protocol::HPACK::Huffman do
 	with '#encode' do
 		huffman_examples.each do |plain, encoded|
 			it "should encode #{plain} into #{encoded}" do
-				expect(huffman.encode(plain).unpack1('H*')).to be == encoded
+				expect(subject.encode(plain).unpack1('H*')).to be == encoded
 			end
 		end
 	end
@@ -28,7 +26,7 @@ describe Protocol::HPACK::Huffman do
 	with '#decode' do
 		huffman_examples.each do |plain, encoded|
 			it "should decode #{encoded} into #{plain}" do
-				expect(huffman.decode([encoded].pack('H*'))).to be == plain
+				expect(subject.decode([encoded].pack('H*'))).to be == plain
 			end
 		end
 
@@ -42,8 +40,8 @@ describe Protocol::HPACK::Huffman do
 			'UTF-8でエンコードした日本語文字列',
 		].each do |string|
 			it "should encode then decode '#{string}' into the same" do
-				encoded = huffman.encode(string.b)
-				expect(huffman.decode(encoded)).to be == string.b
+				encoded = subject.encode(string.b)
+				expect(subject.decode(encoded)).to be == string.b
 			end
 		end
 		
@@ -51,7 +49,7 @@ describe Protocol::HPACK::Huffman do
 			(2**16).times do |n|
 				string = [n].pack('V')[0, 2].b
 				
-				expect(huffman.decode(huffman.encode(string))).to be == string
+				expect(subject.decode(subject.encode(string))).to be == string
 			end
 		end
 		
@@ -60,7 +58,7 @@ describe Protocol::HPACK::Huffman do
 			encoded = [encoded].pack('H*')
 			
 			expect do
-				huffman.decode(encoded[0...-1].b)
+				subject.decode(encoded[0...-1].b)
 			end.to raise_exception(Protocol::HPACK::CompressionError, message: be =~ /EOS invalid/)
 		end
 		
@@ -70,7 +68,7 @@ describe Protocol::HPACK::Huffman do
 			encoded = [encoded].pack('H*')
 			
 			expect do
-				huffman.decode(encoded.b)
+				subject.decode(encoded.b)
 			end.to raise_exception(Protocol::HPACK::CompressionError, message: be =~ /EOS invalid/)
 		end
 		
@@ -80,7 +78,7 @@ describe Protocol::HPACK::Huffman do
 			encoded = [encoded].pack('H*')
 			
 			expect do
-				huffman.decode(encoded.b)
+				subject.decode(encoded.b)
 			end.to raise_exception(Protocol::HPACK::CompressionError, message: be =~ /EOS invalid/)
 		end
 		
@@ -89,7 +87,7 @@ describe Protocol::HPACK::Huffman do
 			encoded = ['1c7fffffffff'].pack('H*')
 			
 			expect do
-				huffman.decode(encoded.b)
+				subject.decode(encoded.b)
 			end.to raise_exception(Protocol::HPACK::CompressionError, message: be =~ /EOS found/)
 		end
 	end


### PR DESCRIPTION
`Protocol::HPACK::Huffman` doesn't maintain any state, so there's no reason for `encode`/`decode` to be instance methods.  Making them class methods means we can avoid allocating instances during header encoding/decoding, which improves performance (~2% on my machine, but the benchmark is a bit noisy).

## Types of Changes

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
