### PR TITLE
compute shifts more directly during decoding

### DIFF
--- a/lib/protocol/hpack/huffman.rb
+++ b/lib/protocol/hpack/huffman.rb
@@ -39,8 +39,9 @@ module Protocol
 
 				mask = (1 << BITS_AT_ONCE) - 1
 				buffer.each_byte do |c|
-					(8 / BITS_AT_ONCE - 1).downto(0) do |shift|
-						branch = (c >> (shift * BITS_AT_ONCE)) & mask
+					shift = BITS_AT_ONCE
+					while shift >= 0
+						branch = (c >> shift) & mask
 						
 						# MACHINE[state] = [final, [transitions]]
 						#  [final] unfinished bits so far are prefix of the EOS code.
@@ -52,6 +53,7 @@ module Protocol
 						raise CompressionError, 'Huffman decode error (EOS found)' if value == EOS
 						
 						emit << value.chr if value
+						shift -= BITS_AT_ONCE
 					end
 				end
 				# Check whether partial input is correctly filled


### PR DESCRIPTION
This code has a lot of overhead (several method sends, multiple block invocations) for what is a fairly simple calculation.  The `while` loop here is not quite as elegant, but it is a good bit faster (3-4% on my local machine).

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
