### PR TITLE
write directly into the buffer in `write_integer`

### DIFF
--- a/lib/protocol/hpack/compressor.rb
+++ b/lib/protocol/hpack/compressor.rb
@@ -75,22 +75,19 @@ module Protocol
 			# @param bits [Integer] number of available bits
 			# @return [String] binary string
 			def write_integer(value, bits)
-				limit = 2**bits - 1
+				limit = (1 << bits) - 1
 				
-				return write_bytes([value].pack('C')) if value < limit
+				return @buffer << value if value < limit
 				
-				bytes = []
-				bytes.push(limit) unless bits.zero?
+				@buffer << limit unless bits.zero?
 				
 				value -= limit
 				while value >= 128
-					bytes.push((value % 128) + 128)
+					@buffer << ((value & 0x7f) + 128)
 					value /= 128
 				end
 				
-				bytes.push(value)
-				
-				write_bytes(bytes.pack('C*'))
+				@buffer << value
 			end
 			
 			def huffman


### PR DESCRIPTION
Packing the individual bytes into a string here (along with constructing the list to pack in the first place) is unnecessary overhead: we can just write the bytes directly.  This change improves compression performance by ~10%.

We also change a few arithmetic operations into operations that the VM has optimized implementations for in the main interpreter loop.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
